### PR TITLE
Fix SlideUpModal close behavior: ensure onClose is called immediately…

### DIFF
--- a/mobile-app/__tests__/Components/SlideUpModal.test.tsx
+++ b/mobile-app/__tests__/Components/SlideUpModal.test.tsx
@@ -45,6 +45,8 @@ describe('SlideUpModal', () => {
 
     const closeButton = getByTestId('close-modal');
     fireEvent.press(closeButton);
+
+    expect(mockOnClose).toHaveBeenCalled();
   });
 
   it('animates correctly on open', () => {

--- a/mobile-app/src/Presentation/Components/notifications/SlideUpModal.tsx
+++ b/mobile-app/src/Presentation/Components/notifications/SlideUpModal.tsx
@@ -42,15 +42,16 @@ const SlideUpModal: React.FC<SlideUpModalProps> = ({
   }, [isVisible]);
 
   const handleClose = () => {
-    // Animar el modal hacia abajo
+    if (onClose) {
+      onClose(); // Llama directamente a `onClose` antes de la animación.
+    }
+
     Animated.timing(slideAnim, {
       toValue: 500, // Posición inicial (fuera de la pantalla)
       duration: 300,
       easing: Easing.in(Easing.ease),
       useNativeDriver: true,
-    }).start(() => {
-      if (onClose) onClose();
-    });
+    }).start();
   };
 
   if (!isVisible) return null;


### PR DESCRIPTION
… when closing the modal